### PR TITLE
Remove unused feature from wasm-bindgen dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ proc-macro = true
 syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
-wasm-bindgen = { version = "0.2.79", features = ["serde-serialize"] }
+wasm-bindgen = "0.2.79"
 js-sys = "0.3.51"


### PR DESCRIPTION
This feature was causing a cyclic dependency via `wasm-bindgen -> js_sys -> [...] -> getrandom` in my project and it is actually not required by this macro.

Fixes #1.