### PR TITLE
Add helper converters to the public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            rust: 1.65.0 # MSRV
+            rust: 1.74.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.65.0 # MSRV
+          - 1.74.0 # MSRV
           - stable
         target:
           - wasm32-unknown-unknown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,8 @@ jobs:
       - name: Generate code coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info --all-features
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.0.1
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Generate code coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info --all-features
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: lcov.info
           fail_ci_if_error: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ members=[
     'wasm-bindgen-derive',
     'tests'
 ]
+resolver = "2"

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -31,6 +31,7 @@ extern "C" {
 }
 
 // Use this type in the function signature.
+#[wasm_bindgen]
 pub fn option_example(value: &OptionMyType) -> Result<OptionMyType, Error> {
     // Use a helper to extract the typed value
     let typed_value = try_from_js_option::<MyType>(value).map_err(|err| Error::new(&err))?;
@@ -53,6 +54,7 @@ extern "C" {
 }
 
 // Use this type in the function signature.
+#[wasm_bindgen]
 pub fn vec_example(val: &MyTypeArray) -> Result<MyTypeArray, Error> {
     // Use a helper to extract the typed array
     let typed_array = try_from_js_array::<MyType>(val).map_err(|err| Error::new(&err))?;
@@ -61,4 +63,16 @@ pub fn vec_example(val: &MyTypeArray) -> Result<MyTypeArray, Error> {
 
     // Return the array
     Ok(into_js_array(typed_array))
+}
+
+// Post wasm-bindgen 0.2.91, we can just return a vector
+#[wasm_bindgen]
+pub fn vec_example_simplified(val: &MyTypeArray) -> Result<Vec<MyType>, Error> {
+    // Use a helper to extract the typed array
+    let typed_array = try_from_js_array::<MyType>(val).map_err(|err| Error::new(&err))?;
+
+    // Now we have `typed_array: Vec<MyType>`.
+
+    // Return the array
+    Ok(typed_array)
 }

--- a/tests/tests/wasm.rs
+++ b/tests/tests/wasm.rs
@@ -1,54 +1,7 @@
-use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::wasm_bindgen_test;
 
+use wasm_bindgen_derive::{into_js_array, into_js_option, try_from_js_array, try_from_js_option};
 use wasm_bindgen_derive_tests::{option_example, vec_example, MyType};
-
-fn into_js_option<T, U>(val: Option<U>) -> T
-where
-    JsValue: From<U>,
-    T: JsCast,
-{
-    let js_val = match val {
-        None => JsValue::UNDEFINED,
-        Some(val) => val.into(),
-    };
-    js_val.unchecked_into::<T>()
-}
-
-fn into_js_array<T, U>(val: impl IntoIterator<Item = U>) -> T
-where
-    JsValue: From<U>,
-    T: JsCast,
-{
-    val.into_iter()
-        .map(JsValue::from)
-        .collect::<js_sys::Array>()
-        .unchecked_into::<T>()
-}
-
-fn try_from_js_option<T>(val: impl Into<JsValue>) -> Option<T>
-where
-    for<'a> T: TryFrom<&'a JsValue>,
-    for<'a> <T as TryFrom<&'a JsValue>>::Error: core::fmt::Debug,
-{
-    let js_val = val.into();
-    if js_val.is_undefined() {
-        return None;
-    }
-    Some(T::try_from(&js_val).unwrap())
-}
-
-fn try_from_js_array<T>(val: impl Into<JsValue>) -> Vec<T>
-where
-    for<'a> T: TryFrom<&'a JsValue>,
-    for<'a> <T as TryFrom<&'a JsValue>>::Error: core::fmt::Debug,
-{
-    let js_array: js_sys::Array = val.into().dyn_into().unwrap();
-    js_array
-        .iter()
-        .map(|js| T::try_from(&js).unwrap())
-        .collect::<Vec<_>>()
-}
 
 #[wasm_bindgen_test]
 fn test_option_example_some() {
@@ -57,7 +10,7 @@ fn test_option_example_some() {
 
     let result_js = option_example(&arg_js).unwrap();
     let result = try_from_js_option::<MyType>(result_js);
-    assert!(result == arg);
+    assert!(result == Ok(arg));
 }
 
 #[wasm_bindgen_test]
@@ -67,7 +20,7 @@ fn test_option_example_none() {
 
     let result_js = option_example(&arg_js).unwrap();
     let result = try_from_js_option::<MyType>(result_js);
-    assert!(result == arg);
+    assert!(result == Ok(arg));
 }
 
 #[wasm_bindgen_test]
@@ -77,5 +30,5 @@ fn test_vec_example() {
 
     let result_js = vec_example(&arg_js).unwrap();
     let result = try_from_js_array::<MyType>(result_js);
-    assert!(result == arg);
+    assert!(result == Ok(arg));
 }

--- a/tests/tests/wasm.rs
+++ b/tests/tests/wasm.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen_test::wasm_bindgen_test;
 
 use wasm_bindgen_derive::{into_js_array, into_js_option, try_from_js_array, try_from_js_option};
-use wasm_bindgen_derive_tests::{option_example, vec_example, MyType};
+use wasm_bindgen_derive_tests::{option_example, vec_example, vec_example_simplified, MyType};
 
 #[wasm_bindgen_test]
 fn test_option_example_some() {
@@ -30,5 +30,14 @@ fn test_vec_example() {
 
     let result_js = vec_example(&arg_js).unwrap();
     let result = try_from_js_array::<MyType>(result_js);
+    assert!(result == Ok(arg));
+}
+
+#[wasm_bindgen_test]
+fn test_vec_example_simplified() {
+    let arg = vec![MyType::new(0), MyType::new(1), MyType::new(2)];
+    let arg_js = into_js_array(arg.clone());
+
+    let result = vec_example_simplified(&arg_js);
     assert!(result == Ok(arg));
 }

--- a/wasm-bindgen-derive-macro/Cargo.toml
+++ b/wasm-bindgen-derive-macro/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 description = "Proc-macro backend for wasm-bindgen-derive"
 repository = "https://github.com/fjarri/wasm-bindgen-derive"
 categories = ["no-std", "wasm"]
-rust-version = "1.65.0"
+rust-version = "1.74.0"
 
 [lib]
 proc-macro = true

--- a/wasm-bindgen-derive-macro/Cargo.toml
+++ b/wasm-bindgen-derive-macro/Cargo.toml
@@ -18,5 +18,5 @@ quote = "1.0"
 proc-macro2 = "1.0"
 
 [dev-dependencies]
-wasm-bindgen = "0.2.85"
+wasm-bindgen = "0.2.91"
 js-sys = "0.3.55"

--- a/wasm-bindgen-derive-macro/tests/integration.rs
+++ b/wasm-bindgen-derive-macro/tests/integration.rs
@@ -18,6 +18,8 @@ struct MyTypeCustomName(usize);
 
 #[test]
 fn pass() {
-    let _x = MyType(1);
-    let _y = MyTypeCustomName(2);
+    let x = MyType(1);
+    assert_eq!(x.0, 1);
+    let y = MyTypeCustomName(2);
+    assert_eq!(y.0, 2);
 }

--- a/wasm-bindgen-derive/Cargo.toml
+++ b/wasm-bindgen-derive/Cargo.toml
@@ -8,7 +8,7 @@ description = "Trait derivation macros for wasm-bindgen"
 repository = "https://github.com/fjarri/wasm-bindgen-derive"
 readme = "../README.md"
 categories = ["no-std", "wasm"]
-rust-version = "1.65.0"
+rust-version = "1.74.0"
 
 [dependencies]
 wasm-bindgen-derive-macro = "0.2.1"

--- a/wasm-bindgen-derive/src/helpers.rs
+++ b/wasm-bindgen-derive/src/helpers.rs
@@ -1,0 +1,90 @@
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use wasm_bindgen::{JsCast, JsValue};
+
+/// Converts the given optional typed value into a JS value with the custom type `T`.
+///
+/// The type `T` would be defined in an `extern "C"` block, e.g.
+/// ```
+/// use wasm_bindgen::prelude::wasm_bindgen;
+/// #[wasm_bindgen]
+/// extern "C" {
+/// #[wasm_bindgen(typescript_type = "MyType | undefined")]
+///     pub type OptionMyType; // <-- this would be `T`
+/// }
+/// ```
+///
+/// If the typed value is `None`, the result is JS `underfined`.
+pub fn into_js_option<T, U>(val: Option<U>) -> T
+where
+    JsValue: From<U>,
+    T: JsCast,
+{
+    let js_val = match val {
+        None => JsValue::UNDEFINED,
+        Some(val) => val.into(),
+    };
+    js_val.unchecked_into::<T>()
+}
+
+/// Attempts to unpack a JS value into a typed value,
+/// returning `None` if the JS value is `undefined`.
+pub fn try_from_js_option<T>(val: impl Into<JsValue>) -> Result<Option<T>, String>
+where
+    for<'a> T: TryFrom<&'a JsValue>,
+    for<'a> <T as TryFrom<&'a JsValue>>::Error: core::fmt::Display,
+{
+    let js_val = val.into();
+    if js_val.is_undefined() {
+        return Ok(None);
+    }
+    T::try_from(&js_val)
+        .map(Some)
+        .map_err(|err| format!("{}", err))
+}
+
+/// Converts the given iterator into a JS array of the custom type `T`.
+///
+/// The type `T` would be defined in an `extern "C"` block, e.g.
+/// ```
+/// use wasm_bindgen::prelude::wasm_bindgen;
+/// #[wasm_bindgen]
+/// extern "C" {
+///     #[wasm_bindgen(typescript_type = "MyType[]")]
+///     pub type MyTypeArray; // <-- this would be `T`
+/// }
+/// ```
+pub fn into_js_array<T, U>(value: impl IntoIterator<Item = U>) -> T
+where
+    JsValue: From<U>,
+    T: JsCast,
+{
+    value
+        .into_iter()
+        .map(JsValue::from)
+        .collect::<js_sys::Array>()
+        .unchecked_into::<T>()
+}
+
+/// Attempts to unpack a JS array into a vector of typed values.
+pub fn try_from_js_array<T>(val: impl Into<JsValue>) -> Result<Vec<T>, String>
+where
+    for<'a> T: TryFrom<&'a JsValue>,
+    for<'a> <T as TryFrom<&'a JsValue>>::Error: core::fmt::Display,
+{
+    let js_val = val.into();
+    let array: &js_sys::Array = js_val.dyn_ref().ok_or("The argument must be an array")?;
+    let length: usize = array
+        .length()
+        .try_into()
+        .map_err(|err| format!("{}", err))?;
+    let mut typed_array = Vec::<T>::with_capacity(length);
+    for (idx, js) in array.iter().enumerate() {
+        let typed_elem =
+            T::try_from(&js).map_err(|err| format!("Failed to cast item {}: {}", idx, err))?;
+        typed_array.push(typed_elem);
+    }
+    Ok(typed_array)
+}

--- a/wasm-bindgen-derive/src/lib.rs
+++ b/wasm-bindgen-derive/src/lib.rs
@@ -16,7 +16,7 @@ See [this issue](https://github.com/rustwasm/wasm-bindgen/issues/2370).
 extern crate alloc;
 use js_sys::Error;
 use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
-use wasm_bindgen_derive::TryFromJsValue;
+use wasm_bindgen_derive::{TryFromJsValue, try_from_js_option, into_js_option};
 
 // Derive `TryFromJsValue` for the target structure (note that it has to come
 // before the `[#wasm_bindgen]` attribute, and requires `Clone`):
@@ -34,18 +34,14 @@ extern "C" {
 
 // Use this type in the function signature.
 pub fn option_example(value: &OptionMyType) -> Result<OptionMyType, Error> {
-    let js_value: &JsValue = value.as_ref();
-    let typed_value: Option<MyType> = if js_value.is_undefined() {
-        None
-    } else {
-        Some(MyType::try_from(js_value).map_err(|err| Error::new(&err))?)
-    };
+    // Use a helper to extract the typed value
+    let typed_value = try_from_js_option::<MyType>(value).map_err(|err| Error::new(&err))?;
 
     // Now we have `typed_value: Option<MyType>`.
 
     // Return it
-    // Note that by default `JsValue::from(None)` creates a `JsValue::UNDEFINED`.
-    Ok(JsValue::from(typed_value).unchecked_into::<OptionMyType>())
+    // Note that if `typed_value` is `None`, `into_js_option()` creates a `JsValue::UNDEFINED`.
+    Ok(into_js_option(typed_value))
 }
 ```
 
@@ -64,7 +60,7 @@ The following example also shows how to return an array with elements having an 
 extern crate alloc;
 use js_sys::Error;
 use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
-use wasm_bindgen_derive::TryFromJsValue;
+use wasm_bindgen_derive::{TryFromJsValue, try_from_js_array, into_js_array};
 
 #[derive(TryFromJsValue)]
 #[wasm_bindgen]
@@ -80,29 +76,13 @@ extern "C" {
 
 // Use this type in the function signature.
 pub fn vec_example(val: &MyTypeArray) -> Result<MyTypeArray, Error> {
-
-    // Unpack the array
-
-    let js_val: &JsValue = val.as_ref();
-    let array: &js_sys::Array = js_val
-        .dyn_ref()
-        .ok_or_else(|| Error::new("The argument must be an array"))?;
-    let length: usize = array.length().try_into().map_err(|err| Error::new(&format!("{}", err)))?;
-    let mut typed_array = Vec::<MyType>::with_capacity(length);
-    for js in array.iter() {
-        let typed_elem = MyType::try_from(&js).map_err(|err| Error::new(&err))?;
-        typed_array.push(typed_elem);
-    }
+    // Use a helper to extract the typed array
+    let typed_array = try_from_js_array::<MyType>(val).map_err(|err| Error::new(&err))?;
 
     // Now we have `typed_array: Vec<MyType>`.
 
     // Return the array
-
-    Ok(typed_array
-        .into_iter()
-        .map(JsValue::from)
-        .collect::<js_sys::Array>()
-        .unchecked_into::<MyTypeArray>())
+    Ok(into_js_array(typed_array))
 }
 ```
 */
@@ -112,4 +92,7 @@ pub fn vec_example(val: &MyTypeArray) -> Result<MyTypeArray, Error> {
 // Ensure it is present. Needed for the generated code to work.
 extern crate alloc;
 
+mod helpers;
+
+pub use helpers::{into_js_array, into_js_option, try_from_js_array, try_from_js_option};
 pub use wasm_bindgen_derive_macro::TryFromJsValue;


### PR DESCRIPTION
- Expose helper functions `into_js_array`, `into_js_option`, `try_from_js_array`, `try_from_js_option` that convert between concrete types and JS values. 
- Bump MSRV to 1.74