### PR TITLE
Upgrade wasm bindgen 0.2.126

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,20 @@ members=[
     'tests'
 ]
 resolver = "2"
+
+[workspace.package]
+version = "0.3.1"
+edition = "2021"
+authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
+license = "MIT"
+repository = "https://github.com/fjarri/wasm-bindgen-derive"
+rust-version = "1.96.0"
+
+[workspace.dependencies]
+js-sys = "0.3.103"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "1.0"
+wasm-bindgen = "=0.2.126"
+wasm-bindgen-derive-macro = { path = "./wasm-bindgen-derive-macro" }
+wasm-bindgen-test = "0.3.76"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "wasm-bindgen-derive-tests"
-version = "0.0.0"
-edition = "2021"
-authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
 
 [dependencies]
 wasm-bindgen-derive = { path = "../wasm-bindgen-derive" }
-wasm-bindgen = "0.2.85"
-js-sys = "0.3.55"
+wasm-bindgen = { workspace = true }
+js-sys = { workspace = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.28"
+wasm-bindgen-test = { workspace = true }

--- a/wasm-bindgen-derive-macro/Cargo.toml
+++ b/wasm-bindgen-derive-macro/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "wasm-bindgen-derive-macro"
-version = "0.3.0"
-edition = "2021"
-authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Proc-macro backend for wasm-bindgen-derive"
-repository = "https://github.com/fjarri/wasm-bindgen-derive"
+repository.workspace = true
 categories = ["no-std", "wasm"]
-rust-version = "1.74.0"
+rust-version.workspace = true
 
 [lib]
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
 
 [dev-dependencies]
-wasm-bindgen = "0.2.91"
-js-sys = "0.3.55"
+wasm-bindgen = { workspace = true }
+js-sys = { workspace = true }

--- a/wasm-bindgen-derive-macro/src/lib.rs
+++ b/wasm-bindgen-derive-macro/src/lib.rs
@@ -167,7 +167,8 @@ pub fn derive_try_from_jsvalue(input: TokenStream) -> TokenStream {
                     let ptr_u32: u32 = ptr.as_f64().ok_or(::wasm_bindgen::JsValue::NULL)
                         .map_err(|err| format!("{:?}", err))?
                         as u32;
-                    let instance_ref = unsafe { #name::ref_from_abi(ptr_u32) };
+                    let ptr_abi: wasm_bindgen::__rt::WasmPtr<wasm_bindgen::__rt::WasmRefCell<#name>> = wasm_bindgen::__rt::WasmPtr::from_usize(ptr_u32 as usize);
+                    let instance_ref = unsafe { #name::ref_from_abi(ptr_abi) };
                     Ok(instance_ref.clone())
                 } else {
                     Err(format!("Cannot convert {} to {}", object_classname, classname))

--- a/wasm-bindgen-derive/Cargo.toml
+++ b/wasm-bindgen-derive/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "wasm-bindgen-derive"
-version = "0.3.0"
-edition = "2021"
-authors = ["Bogdan Opanchuk <bogdan@opanchuk.net>"]
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Trait derivation macros for wasm-bindgen"
-repository = "https://github.com/fjarri/wasm-bindgen-derive"
+repository.workspace = true
 readme = "../README.md"
 categories = ["no-std", "wasm"]
-rust-version = "1.74.0"
+rust-version.workspace = true
 
 [dependencies]
-wasm-bindgen-derive-macro = "0.3.0"
-wasm-bindgen = "0.2.85"
-js-sys = "0.3.55"
+js-sys = { workspace = true }
+wasm-bindgen-derive-macro = { workspace = true }
+wasm-bindgen = { workspace = true }


### PR DESCRIPTION
Upgrade wasm-bindgen version to 0.2.126. Fix TryFromJsValue macro mismatched types error